### PR TITLE
fix:only approved agencies can upload properties

### DIFF
--- a/site/server-actions/property/add-property.ts
+++ b/site/server-actions/property/add-property.ts
@@ -3,16 +3,26 @@ import database from "@/db";
 import { MyError, Errors } from "@/constants/errors";
 import { Properties } from "@/db/collections";
 import { MongoServerError } from "mongodb";
-import { requireAnyRole } from "@/auth/utils";
+import { AuthError, requireAnyRole } from "@/auth/utils";
+import { UserModel } from "@/db/models/user";
 
 export async function AddProperty(FormData: Properties) {
   try {
-    await requireAnyRole("admin", "agency");
+    const payload = await requireAnyRole("admin", "agency");
+    if (payload.role === "agency") {
+      const agency = await UserModel.findById(payload.userId);
+      if (agency?.status !== "APPROVED") {
+        throw new AuthError("Your agency has not been approved yet");
+      }
+    }
     await database.AddProperty(FormData);
   } catch (error) {
     if (error instanceof MongoServerError && error.code === 11000) {
       // Duplicate key error from Mongo
       throw new MyError("The property already exists");
+    }
+    if (error instanceof AuthError) {
+      throw new MyError(error.message, { cause: error });
     }
     console.error("Error adding property", { cause: error });
     throw new MyError(Errors.NOT_ADD_PROPERTY);


### PR DESCRIPTION
This pull request enhances the property addition logic by introducing an approval check for agency users and improving error handling. Now, only agencies with an "APPROVED" status can add properties, and authentication errors are handled more gracefully.

**Access control improvements:**

* Added a check in `AddProperty` to ensure that if the user has the "agency" role, their agency must have an "APPROVED" status before allowing property addition (`site/server-actions/property/add-property.ts`).

**Error handling improvements:**

* Introduced handling for `AuthError` exceptions, converting them into user-friendly error messages using `MyError` (`site/server-actions/property/add-property.ts`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Enforces that only approved agency accounts (and admins) can add properties, preventing actions by unapproved agencies.
  - Improves authorization error handling to provide clearer feedback to users.
  - Preserves existing handling for duplicate entries while enhancing reliability of access checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->