### PR TITLE
Ft/update agent properties

### DIFF
--- a/site/app/(platform)/agencies/dashboard/_components/agentDashboardStatisticsItem.tsx
+++ b/site/app/(platform)/agencies/dashboard/_components/agentDashboardStatisticsItem.tsx
@@ -8,12 +8,16 @@ export default function AgentDashboardStatisticsItem(
   props: AgentDashboardStatisticsData,
 ) {
   return (
-    <section className="p-4 border border-solid rounded-md border-slate-300">
-      <header className="flex flex-row justify-between mb-2 font-bold text-sm">
-        <h3>{props.title}</h3>
-        {props.icon}
-      </header>
-      <p>{props.value}</p>
-    </section>
+    <div className="bg-white rounded-xl border border-gray-200 p-6 shadow-sm hover:shadow-md transition-shadow duration-200">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-sm font-medium text-gray-600 uppercase tracking-wide">
+          {props.title}
+        </h3>
+        <div className="text-gray-400 opacity-60">{props.icon}</div>
+      </div>
+      <p className="text-2xl font-bold text-gray-900 leading-none">
+        {props.value}
+      </p>
+    </div>
   );
 }

--- a/site/app/(platform)/agencies/dashboard/_components/dashboardStatistics.tsx
+++ b/site/app/(platform)/agencies/dashboard/_components/dashboardStatistics.tsx
@@ -1,35 +1,32 @@
-"use server"
-
-import { DollarSign, House, Percent, Users } from "lucide-react";
+import { TrendingUp, Building2, Users, BarChart3 } from "lucide-react";
 import AgentDashboardStatisticsItem from "./agentDashboardStatisticsItem";
 import getAgencyStatistics from "@/server-actions/agent/dashboard/getStatistics";
 
 export default async function AgentDashboardStatistics() {
-    const statistics = await getAgencyStatistics();
+  const statistics = await getAgencyStatistics();
 
-    return (
-        <article className="lg:grid lg:grid-cols-2 lg:gap-4 flex flex-col gap-3 mb-4">
-            <AgentDashboardStatisticsItem
-                title="Total Earnings"
-                icon={<DollarSign className="w-4 h-4" />}
-                value={`$${statistics.totalEarnings}`}
-            />
-            <AgentDashboardStatisticsItem
-                title="Occupancy Rate"
-                icon={<Percent className="w-4 h-4" />}
-                value={`${statistics.occupancyRate}%`}
-            />
-            <AgentDashboardStatisticsItem
-                title="Total Properties"
-                icon={<House className="w-4 h-4" />}
-                value={statistics.totalProperties.toString()}
-            />
-            <AgentDashboardStatisticsItem
-                title="Active Tenants"
-                icon={<Users className="w-4 h-4" />}
-                value={statistics.activeTenants.toString()}
-            />
-        </article>
-
-    );
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-6 mb-8">
+      <AgentDashboardStatisticsItem
+        title="Total Earnings"
+        icon={<TrendingUp className="w-4 h-4" />}
+        value={`$${statistics.totalEarnings.toLocaleString()}`}
+      />
+      <AgentDashboardStatisticsItem
+        title="Occupancy Rate"
+        icon={<BarChart3 className="w-4 h-4" />}
+        value={`${statistics.occupancyRate}%`}
+      />
+      <AgentDashboardStatisticsItem
+        title="Total Properties"
+        icon={<Building2 className="w-4 h-4" />}
+        value={statistics.totalProperties.toString()}
+      />
+      <AgentDashboardStatisticsItem
+        title="Active Tenants"
+        icon={<Users className="w-4 h-4" />}
+        value={statistics.activeTenants.toString()}
+      />
+    </div>
+  );
 }

--- a/site/app/(platform)/agencies/dashboard/page.tsx
+++ b/site/app/(platform)/agencies/dashboard/page.tsx
@@ -27,51 +27,48 @@ export default async function AgentDashboard({ searchParams }: PageProps) {
   const tenantsPageNum = parsePage(tenantsPage);
 
   return (
-    <main className="md:p-12 p-2">
-      <header className="flex lg:flex-row flex-col lg:justify-between gap-4 my-4">
-        <div>
-          <h1 className="text-2xl font-bold">Agent Dashboard</h1>
-          <p className=" text-sm mt-1  text-muted-foreground">
+    <main className="p-4 md:p-6 lg:p-8 max-w-7xl mx-auto">
+      <header className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4 mb-8">
+        <div className="space-y-1">
+          <h1 className="text-2xl lg:text-3xl font-bold">Agent Dashboard</h1>
+          <p className="text-sm text-muted-foreground">
             Manage your properties and track tenants
           </p>
         </div>
 
-        <Button className="font-semibold" asChild>
+        <Button className="font-semibold w-fit" asChild>
           <Link href={"/agencies/register"}>
-            <Plus />
-            <p>Add New Property</p>
+            <Plus className="w-4 h-4" />
+            Add New Property
           </Link>
         </Button>
       </header>
 
-      <Suspense fallback={<LoadingAgentDashboardStatistics />}>
-        <AgentDashboardStatistics />
-      </Suspense>
+      <div className="space-y-8">
+        <Suspense fallback={<LoadingAgentDashboardStatistics />}>
+          <AgentDashboardStatistics />
+        </Suspense>
 
-      <article>
-        <div>
-          <Tabs defaultValue="properties" className="w-full">
-            <TabsList className="w-full flex-row justify-between">
-              <TabsTrigger value="properties" className="flex-1">
-                Properties
-              </TabsTrigger>
-              <TabsTrigger value="tenants" className="flex-1">
-                Tenants
-              </TabsTrigger>
-            </TabsList>
-            <TabsContent value="properties">
+        <Tabs defaultValue="properties" className="w-full">
+          <TabsList className="grid w-full grid-cols-2">
+            <TabsTrigger value="properties">Properties</TabsTrigger>
+            <TabsTrigger value="tenants">Tenants</TabsTrigger>
+          </TabsList>
+
+          <div className="mt-6">
+            <TabsContent value="properties" className="mt-0">
               <Suspense fallback={<LoadingAgentDashboardProperties />}>
                 <AgentDashboardProperties page={propertiesPageNum} />
               </Suspense>
             </TabsContent>
-            <TabsContent value="tenants">
+            <TabsContent value="tenants" className="mt-0">
               <Suspense fallback={<LoadingAgentDashboardTenants />}>
                 <AgentDashboardTenants page={tenantsPageNum} />
               </Suspense>
             </TabsContent>
-          </Tabs>
-        </div>
-      </article>
+          </div>
+        </Tabs>
+      </div>
     </main>
   );
 }

--- a/site/components/app-navbar.tsx
+++ b/site/components/app-navbar.tsx
@@ -14,9 +14,8 @@ import {
 } from "@/components/ui/resizable-navbar";
 import { useState } from "react";
 import { WalletConnect } from "@/components/wallet-connect";
-import { logout } from "@/server-actions/auth/auth";
 import { UserRole } from "@/auth/utils";
-
+import { LogoutButton } from "./logout-button";
 interface AppNavbarProps {
   role: UserRole;
 }
@@ -28,10 +27,6 @@ export function AppNavbar({ role }: AppNavbarProps) {
     setIsMobileMenuOpen(false);
   };
 
-  const handleLogout = async () => {
-    setIsMobileMenuOpen(false);
-    await logout();
-  };
   return (
     <Navbar>
       {/* Desktop Navigation */}
@@ -50,9 +45,7 @@ export function AppNavbar({ role }: AppNavbarProps) {
 
         <div className="flex items-center gap-4">
           <WalletConnect />
-          <NavbarButton variant="primary" as="button" onClick={logout}>
-            Logout
-          </NavbarButton>
+          <LogoutButton variant="primary" />
         </div>
       </NavBody>
 
@@ -93,14 +86,7 @@ export function AppNavbar({ role }: AppNavbarProps) {
 
           <div className="flex w-full flex-col gap-4 pt-4 border-t border-neutral-200 dark:border-neutral-700">
             <WalletConnect />
-            <NavbarButton
-              variant="primary"
-              className="w-full"
-              as="button"
-              onClick={handleLogout}
-            >
-              Logout
-            </NavbarButton>
+            <LogoutButton variant="primary" />
           </div>
         </MobileNavMenu>
       </MobileNav>

--- a/site/components/logout-button.tsx
+++ b/site/components/logout-button.tsx
@@ -1,0 +1,121 @@
+"use client";
+import { useState } from "react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { logout } from "@/server-actions/auth/auth";
+import { NavbarButton } from "@/components/ui/resizable-navbar";
+import { cn } from "@/lib/utils";
+import { Spinner } from "./ui/spinner";
+import { toast } from "sonner";
+
+interface LogoutButtonProps {
+  variant?: "primary" | "secondary" | "dark" | "gradient";
+  className?: string;
+  onLogoutStart?: () => void;
+  onLogoutComplete?: () => void;
+  onCancel?: () => void;
+  children?: React.ReactNode;
+  size?: "sm" | "md" | "lg";
+}
+
+export function LogoutButton({
+  variant = "primary",
+  className,
+  onLogoutStart,
+  onLogoutComplete,
+  onCancel,
+  children = "Logout",
+  size = "md",
+}: LogoutButtonProps) {
+  const [isLoggingOut, setIsLoggingOut] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleConfirmLogout = async () => {
+    try {
+      setIsLoggingOut(true);
+      onLogoutStart?.();
+
+      await logout();
+
+      onLogoutComplete?.();
+    } catch (error) {
+      console.error(error);
+    } finally {
+      setIsLoggingOut(false);
+      setIsOpen(false);
+    }
+  };
+
+  const handleCancel = () => {
+    setIsOpen(false);
+    onCancel?.();
+  };
+
+  const getSizeClasses = () => {
+    switch (size) {
+      case "sm":
+        return "px-3 py-1.5 text-xs";
+      case "lg":
+        return "px-6 py-3 text-base";
+      default:
+        return "px-4 py-2 text-sm";
+    }
+  };
+
+  return (
+    <AlertDialog open={isOpen} onOpenChange={setIsOpen}>
+      <AlertDialogTrigger asChild>
+        <NavbarButton
+          variant={variant}
+          as="button"
+          className={cn(getSizeClasses(), className)}
+          disabled={isLoggingOut}
+        >
+          {isLoggingOut ? "Logging out..." : children}
+        </NavbarButton>
+      </AlertDialogTrigger>
+
+      <AlertDialogContent className="sm:max-w-[425px]">
+        <AlertDialogHeader>
+          <AlertDialogTitle className="text-lg ">
+            Confirm Logout
+          </AlertDialogTitle>
+          <AlertDialogDescription className="text-muted-foreground text-sm">
+            Are you sure you want to log out? You'll need to sign in again to
+            access your account.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        <AlertDialogFooter>
+          <AlertDialogCancel
+            className="hover:text-black hover:bg-slate-50 cursor-pointer "
+            onClick={handleCancel}
+            disabled={isLoggingOut}
+          >
+            Cancel
+          </AlertDialogCancel>
+          <AlertDialogAction
+            onClick={handleConfirmLogout}
+            disabled={isLoggingOut}
+            className="bg-red-600 hover:bg-red-700 focus:ring-red-600"
+          >
+            {isLoggingOut ? (
+              <Spinner size="small" className="text-white" />
+            ) : (
+              "Yes"
+            )}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/site/components/ui/alert-dialog.tsx
+++ b/site/components/ui/alert-dialog.tsx
@@ -1,0 +1,157 @@
+"use client"
+
+import * as React from "react"
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+
+import { cn } from "@/lib/utils"
+import { buttonVariants } from "@/components/ui/button"
+
+function AlertDialog({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+}
+
+function AlertDialogTrigger({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return (
+    <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+  )
+}
+
+function AlertDialogPortal({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return (
+    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+  )
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="alert-dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          className
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  )
+}
+
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn("text-lg font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogAction({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
+  return (
+    <AlertDialogPrimitive.Action
+      className={cn(buttonVariants(), className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogCancel({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
+  return (
+    <AlertDialogPrimitive.Cancel
+      className={cn(buttonVariants({ variant: "outline" }), className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+}

--- a/site/package.json
+++ b/site/package.json
@@ -11,6 +11,7 @@
     "@hashgraph/sdk": "^2.72.0",
     "@hookform/resolvers": "^5.2.1",
     "@mantine/hooks": "^8.2.8",
+    "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@mantine/hooks':
         specifier: ^8.2.8
         version: 8.3.1(react@19.1.0)
+      '@radix-ui/react-alert-dialog':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-checkbox':
         specifier: ^1.3.3
         version: 1.3.3(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -1162,6 +1165,19 @@ packages:
 
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+
+  '@radix-ui/react-alert-dialog@1.1.15':
+    resolution: {integrity: sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
 
   '@radix-ui/react-arrow@1.1.7':
     resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
@@ -6715,6 +6731,20 @@ snapshots:
   '@radix-ui/number@1.1.1': {}
 
   '@radix-ui/primitive@1.1.3': {}
+
+  '@radix-ui/react-alert-dialog@1.1.15(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.12)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.12)(react@19.1.0)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.12)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.1.9(@types/react@19.1.12)
 
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:

--- a/site/server-actions/auth/auth.ts
+++ b/site/server-actions/auth/auth.ts
@@ -89,15 +89,13 @@ export async function authenticate(
 export async function logout() {
   try {
     await tokenMaker.clearTokens();
-    redirect("/");
   } catch (error) {
-    console.error("Logout error:", error);
-    // Still clear tokens and redirect even if revocation fails
-    await tokenMaker.clearTokens();
-    redirect("/");
+    console.error("Error clearing tokens:", error);
   }
-}
 
+  // Always redirect - this throws NEXT_REDIRECT internally (expected behavior)
+  redirect("/");
+}
 // Get current authenticated user
 export async function getCurrentUser() {
   return await tokenMaker.getCurrentUser();


### PR DESCRIPTION
This pull request introduces several improvements to the agent dashboard UI and enhances the logout experience with a confirmation dialog. 

**UI/UX Improvements:**

* Refactored the dashboard statistics section for a more modern look, including updated icons, improved layout, and better number formatting in `AgentDashboardStatisticsItem` and `dashboardStatistics.tsx`. [[1]](diffhunk://#diff-f17b9ed1e7e7ea35ec15a3499a57131eee97f474d5afa25b8775cf38cf2a4fc2L11-R21) [[2]](diffhunk://#diff-878496b2ceb947c61c07cf31c6919f19b036f9c4ad6090c3a2031ed56b24628aL1-R30)
* Redesigned the main dashboard layout with improved spacing, typography, and tab navigation for a cleaner and more responsive experience in `page.tsx`.

**Logout Flow Enhancement:**

* Replaced the direct logout action in the navbar with a new `LogoutButton` component that shows a confirmation dialog before logging out, improving user experience and preventing accidental logouts. [[1]](diffhunk://#diff-94f3a8884c2eb86ec50258ad85125d74894c10d619df093bb994b287b31f9d84L17-R18) [[2]](diffhunk://#diff-94f3a8884c2eb86ec50258ad85125d74894c10d619df093bb994b287b31f9d84L31-L34) [[3]](diffhunk://#diff-94f3a8884c2eb86ec50258ad85125d74894c10d619df093bb994b287b31f9d84L53-R48) [[4]](diffhunk://#diff-94f3a8884c2eb86ec50258ad85125d74894c10d619df093bb994b287b31f9d84L96-R89) [[5]](diffhunk://#diff-ddb4c499e4e898ba4b5a9332c3a683e85a54bd07d711430ef8039040fdc4d620R1-R121)
* Updated the `logout` server action to always redirect after clearing tokens, ensuring consistent behavior.

**Component and Dependency Additions:**

* Added a reusable `AlertDialog` component based on Radix UI for consistent confirmation dialogs across the app.
* Installed `@radix-ui/react-alert-dialog` and updated lockfiles to support the new dialog component. [[1]](diffhunk://#diff-35f15d66f9b39b506a11ac9b5c6b9a80e11b41bfd56832ab130372902258ccf7R14) [[2]](diffhunk://#diff-28fd666fc4ef5763e442c8dab8ee5f27ef99c81eafb4d9779bed158340267859R20-R22) [[3]](diffhunk://#diff-28fd666fc4ef5763e442c8dab8ee5f27ef99c81eafb4d9779bed158340267859R1169-R1181) [[4]](diffhunk://#diff-28fd666fc4ef5763e442c8dab8ee5f27ef99c81eafb4d9779bed158340267859R6735-R6748)