### PR TITLE
feat:added server action for updating properties

### DIFF
--- a/site/constants/errors.ts
+++ b/site/constants/errors.ts
@@ -8,6 +8,7 @@ export class MyError extends Error {
 export enum Errors {
   UNAUTHORIZED = "Unauthorized",
   NOT_ADD_PROPERTY = "Could not add property",
+  NOT_UPDATE_PROPERTY = "Could not update property",
   NOT_GET_PROPERTIES = "Could not get properties",
   NOT_ADD_AGENCY = "Could not add agency",
   NOT_GET_AGENCIES = "Could not get agencies",

--- a/site/db/models/agency.ts
+++ b/site/db/models/agency.ts
@@ -239,12 +239,17 @@ export class AgencyModel {
       throw new MyError(Errors.NOT_GET_PROPERTY, { cause: err });
     }
   }
-  static async updateProperty(_id: ObjectId, data: Partial<Properties>) {
+  static async updateProperty(
+    _id: ObjectId,
+    agencyId: string,
+    data: Partial<Properties>,
+  ) {
     try {
       const collection = await this.getPropertiesCollection();
       const result = await collection.findOneAndUpdate(
         {
           _id: _id,
+          agencyId: agencyId,
         },
         {
           $set: {

--- a/site/db/models/agency.ts
+++ b/site/db/models/agency.ts
@@ -239,8 +239,29 @@ export class AgencyModel {
       throw new MyError(Errors.NOT_GET_PROPERTY, { cause: err });
     }
   }
-  static async updateProperty() {
-    throw new Error("updateProperty is not implemented yet");
+  static async updateProperty(_id: ObjectId, data: Partial<Properties>) {
+    try {
+      const collection = await this.getPropertiesCollection();
+      const result = await collection.findOneAndUpdate(
+        {
+          _id: _id,
+        },
+        {
+          $set: {
+            ...data,
+            updatedAt: new Date(),
+          },
+        },
+        { returnDocument: "after" },
+      );
+      if (!result) {
+        throw new MyError("Property does not exist");
+      }
+      return result;
+    } catch (err) {
+      console.error(err);
+      throw new MyError(Errors.NOT_UPDATE_PROPERTY, { cause: err });
+    }
   }
   // Delete a property associated with an agency
   static async deleteAgencyProperty(
@@ -253,6 +274,7 @@ export class AgencyModel {
         _id: _id,
         agencyId: agencyId,
       });
+
       return !!deletedDocument;
     } catch (err) {
       console.error(err);
@@ -333,7 +355,10 @@ export class AgencyModel {
       const dashboardProperties: DashboardProperties[] = [];
 
       for await (const property of cursor) {
-        const details: { title: string; value: string }[] = [];
+        const details: {
+          title: string;
+          value: string;
+        }[] = [];
 
         if (property.amenities.bedrooms) {
           details.push({

--- a/site/server-actions/agent/dashboard/updateProperty.ts
+++ b/site/server-actions/agent/dashboard/updateProperty.ts
@@ -9,11 +9,15 @@ import { revalidatePath } from "next/cache";
 
 export async function updateProperty(_id: string, data: Partial<Properties>) {
   try {
-    await requireRole("agency");
+    const payload = await requireRole("agency");
     if (!ObjectId.isValid(_id)) {
       throw new MyError("Invalid property id");
     }
-    const result = await AgencyModel.updateProperty(new ObjectId(_id), data);
+    const result = await AgencyModel.updateProperty(
+      new ObjectId(_id),
+      payload.userId,
+      data,
+    );
     revalidatePath("/agencies/dashboard");
     return result;
   } catch (err) {

--- a/site/server-actions/agent/dashboard/updateProperty.ts
+++ b/site/server-actions/agent/dashboard/updateProperty.ts
@@ -1,0 +1,27 @@
+"use server";
+
+import { AuthError, requireRole } from "@/auth/utils";
+import { Errors, MyError } from "@/constants/errors";
+import { Properties } from "@/db/collections";
+import { AgencyModel } from "@/db/models/agency";
+import { ObjectId } from "mongodb";
+import { revalidatePath } from "next/cache";
+
+export async function updateProperty(_id: string, data: Partial<Properties>) {
+  try {
+    await requireRole("agency");
+    if (!ObjectId.isValid(_id)) {
+      throw new MyError("Invalid property id");
+    }
+    const result = await AgencyModel.updateProperty(new ObjectId(_id), data);
+    revalidatePath("/agencies/dashboard");
+    return result;
+  } catch (err) {
+    console.error(err);
+    if (err instanceof AuthError) {
+      throw new MyError(err.message, { cause: err });
+    }
+
+    throw new MyError(Errors.NOT_UPDATE_PROPERTY, { cause: err });
+  }
+}


### PR DESCRIPTION
This pull request adds support for updating property records in the agency dashboard, including both backend model logic and a new server action. The main focus is on implementing the `updateProperty` functionality, handling errors appropriately, and ensuring the dashboard reflects changes.

**New property update functionality:**

* Implemented the `updateProperty` method in `AgencyModel`, allowing properties to be updated by their `_id` and updating the `updatedAt` timestamp. Includes error handling for non-existent properties and database issues.
* Added a new server action `updateProperty` in `site/server-actions/agent/dashboard/updateProperty.ts` that validates user role, checks the property ID, calls the model update method, revalidates the dashboard path, and handles errors.

**Error handling improvements:**

* Added a new error type `NOT_UPDATE_PROPERTY` to the `Errors` enum for consistency in error reporting when property updates fail.

**Minor code cleanup:**

* Minor formatting improvements in the `getDashboardProperties` method for clarity.
* Minor whitespace adjustment in the `deleteAgencyProperty` method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Agents can now update property details directly from the dashboard.
  - Updates are immediately reflected after saving, ensuring the dashboard shows the latest information.
- Bug Fixes
  - Improved validation of property identifiers to prevent failed updates.
  - Clearer error messaging when updates cannot be completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->